### PR TITLE
コメント投稿機能

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,18 @@
+class CommentsController < ApplicationController
+  def create
+    @comment = Comment.new(comment_params)
+    if @comment.save
+      redirect_to prototype_path(@comment.prototype)
+    else
+      @prototype = @comment.prototype
+      @comments = @prototype.comments
+      render "prototypes/show", status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:content).merge(user_id: current_user.id, prototype_id: params[:prototype_id])
+  end
+end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -19,6 +19,8 @@ class PrototypesController < ApplicationController
 
   def show
     @prototype = Prototype.find(params[:id])
+    @comment = Comment.new
+    @comments = @prototype.comments.includes(:user)
   end
 
   private

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,2 @@
+module CommentsHelper
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,5 @@
+class Comment < ApplicationRecord
+  belongs_to :prototype
+  belongs_to :user
+  validates :content, presence: true
+end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,6 +1,7 @@
 class Prototype < ApplicationRecord
   belongs_to :user
   has_one_attached :image
+  has_many :comments, dependent: :destroy
   validates :title, presence: true
   validates :catch_copy, presence: true
   validates :concept, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,5 @@ class User < ApplicationRecord
   validates :occupation, presence: true
   validates :position, presence: true
   has_many :prototypes
+  has_many :comments
 end

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -29,24 +29,24 @@
         </div>
       </div>
       <div class="prototype__comments">
-        <%# ログインしているユーザーには以下のコメント投稿フォームを表示する %>
-          <%# <%= form_with model: モデル名,local: true do |f|%>
+        <% if user_signed_in? %>
+          <%= form_with model: [@prototype, @comment],local: true do |f| %>
             <div class="field">
-              <%# <%= f.label :hoge, "コメント" %><br />
-              <%# <%= f.text_field :hoge, id:"comment_content" %>
+              <%= f.label :content, "コメント" %><br />
+              <%= f.text_field :content, id:"comment_content" %>
             </div>
             <div class="actions">
-              <%# <%= f.submit "送信する", class: :form__btn  %>
+              <%= f.submit "送信する", class: :form__btn %>
             </div>
-          <%# <% end %>
-        <%# // ログインしているユーザーには上記を表示する %>
+          <% end %>
+        <% end %>
         <ul class="comments_lists">
-          <%# 投稿に紐づくコメントを一覧する処理を記述する %>
+          <% @comments.each do |comment| %>
             <li class="comments_list">
-              <%# <%= " コメントのテキスト "%>
-              <%# <%= link_to "（ ユーザー名 ）", root_path, class: :comment_user %>
+              <%= comment.content %>
+              <%= link_to comment.user.name, root_path, class: :comment_user %>
             </li>
-          <%# // 投稿に紐づくコメントを一覧する処理を記述する %>
+          <% end %>
         </ul>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users
   root to:'prototypes#index'
-  resources :prototypes, only: [:index, :new, :create, :show]
+  resources :prototypes, only: [:index, :new, :create, :show] do
+    resources :comments, only: :create
+  end
   # Defines the root path route ("/")
   # root "articles#index"
 end

--- a/db/migrate/20241112054140_create_comments.rb
+++ b/db/migrate/20241112054140_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :comments do |t|
+      t.text :content, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :prototype, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_11_072840) do
+ActiveRecord::Schema[7.0].define(version: 2024_11_12_054140) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -37,6 +37,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_11_072840) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "comments", charset: "utf8mb3", force: :cascade do |t|
+    t.text "content", null: false
+    t.bigint "user_id", null: false
+    t.bigint "prototype_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["prototype_id"], name: "index_comments_on_prototype_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "prototypes", charset: "utf8mb3", force: :cascade do |t|
@@ -67,5 +77,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_11_072840) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "prototypes"
+  add_foreign_key "comments", "users"
   add_foreign_key "prototypes", "users"
 end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### What
- commentモデルとcommentsテーブルを作成
- モデルにバリデーションの設定
- commentsコントローラーの作成・アクション定義とルーティングの設定（ネストも）
- コメント投稿機能の実装（コントローラーとビューファイルを編集）
- コメントの詳細ページでの表示機能を実装
### Why
- ログインしたユーザーがプロトタイプにコメントを投稿できるようにするため
- プロトタイプについたコメントを見られるようにするため

### Gyazo動画
- 必要な情報を適切に入力して「送信する」ボタンを押すと、投稿したコメントとその投稿者名が対象プロトタイプの詳細ページに表示される動画。
[![Image from Gyazo](https://i.gyazo.com/2e7adea42b810bddba1328499c217f67.gif)](https://gyazo.com/2e7adea42b810bddba1328499c217f67)
- ログアウト状態で、プロトタイプ詳細ページに遷移し、コメント投稿フォームが表示されない動画。
[![Image from Gyazo](https://i.gyazo.com/e1d1e49260241b43c050d3916baf434a.gif)](https://gyazo.com/e1d1e49260241b43c050d3916baf434a)
- フォームを空のまま投稿しようとすると、投稿できずにそのページに留まること。
[![Image from Gyazo](https://i.gyazo.com/8b8768f5043b62826fc0a9144aaf2428.gif)](https://gyazo.com/8b8768f5043b62826fc0a9144aaf2428)
